### PR TITLE
Simplify '/distribution/releases/rome/errata.md' bluetooth troubleshot command

### DIFF
--- a/distribution/releases/rome/errata.md
+++ b/distribution/releases/rome/errata.md
@@ -247,7 +247,7 @@ As a workaround remove `dnf-utils`.
 For bluetooth devices user may need to enable systemd bluetooth.service. Open Konsole
 and run:
 
-`$ sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`
+`$ sudo systemctl enable --now bluetooth`
 <br>
 
 ### SystemSettings


### PR DESCRIPTION
Replace the pair of commands for Bluetooth troubleshooting in the Errata with a single command that achieves the same result (minor change but hey, the simpler the better!)

\* still reading all docs before moving this PR from its draft state, sorry if this isn't the right place