### PR TITLE
Simplify '/[lang]/distribution/releases/[release]/errata.md' bluetooth troubleshoot command

### DIFF
--- a/distribution/releases/omlx60/errata.md
+++ b/distribution/releases/omlx60/errata.md
@@ -217,7 +217,7 @@ As a workaround remove `dnf-utils`.
 For bluetooth devices user may need to enable systemd bluetooth.service. Open Konsole
 and run:
 
-`$ sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`
+`$ sudo systemctl enable --now bluetooth`
 <br>
 
 ### SystemSettings

--- a/distribution/releases/rome/errata.md
+++ b/distribution/releases/rome/errata.md
@@ -247,7 +247,7 @@ As a workaround remove `dnf-utils`.
 For bluetooth devices user may need to enable systemd bluetooth.service. Open Konsole
 and run:
 
-`$ sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`
+`$ sudo systemctl enable --now bluetooth`
 <br>
 
 ### SystemSettings

--- a/fr/distribution/releases/omlx60/errata.md
+++ b/fr/distribution/releases/omlx60/errata.md
@@ -219,7 +219,7 @@ Comme solution de contournement, supprimez `dnf-utils`.
 Pour les périphériques Bluetooth, l'utilisateur peut avoir besoin d'activer systemd bluetooth.service. Ouvrir Konsole
 et exécutez :
 
-`$ sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`
+`$ sudo systemctl enable --now bluetooth`
 <br>
 
 ### SystemSettings

--- a/fr/distribution/releases/rome/errata.md
+++ b/fr/distribution/releases/rome/errata.md
@@ -247,7 +247,7 @@ Comme solution de contournement, supprimez `dnf-utils`.
 Pour les périphériques Bluetooth, l'utilisateur peut avoir besoin d'activer systemd bluetooth.service. Ouvrir Konsole
 et exécutez :
 
-`$ sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`
+`$ sudo systemctl enable --now bluetooth`
 <br>
 
 ### SystemSettings


### PR DESCRIPTION
Replace the pair of commands for Bluetooth troubleshooting in the Erratas where they appear with a single command that achieves the same result (minor change but hey, the simpler the better!)

Before:
`sudo systemctl start bluetooth ; sudo systemctl enable bluetooth`

After:
`sudo systemctl enable --now bluetooth`